### PR TITLE
Prevent duplicate splash screen of Android 12 or above

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,8 +3,9 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
-        <item name="android:windowDisablePreview">true</item>
         <item name="android:textColor">#000000</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowIsTranslucent">true</item> 
     </style>
 
 </resources>


### PR DESCRIPTION
This pull request prevents the duplicate splash screen caused by the default splash screen of Android 12 and above.