### PR TITLE
Use user's UUID when sending the Visit API request

### DIFF
--- a/app/services/visit_service.js
+++ b/app/services/visit_service.js
@@ -21,6 +21,7 @@ class VisitService extends WebService {
     return {
       visit: {
         user_id: !!user ? user.id : null,
+        user_uuid: visit.user_uuid,
         visit_date: visit.visit_date,
         pageable_id: visit.pageable_id,
         pageable_type: visit.pageable_type,


### PR DESCRIPTION
This pull request adds the user's UUID when sending the Visit API request.

Note: The survey form submission API already uses the user's UUID.