### PR TITLE
Prevent error when delete Sidekiq, remove user_id when sending Visit …

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="org.instedd.ilabsea.myjourneys">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 
     <application
       android:name=".MainApplication"

--- a/app/models/Sidekiq.js
+++ b/app/models/Sidekiq.js
@@ -26,7 +26,8 @@ const Sidekiq = (() => {
   function destroy(paramUuid) {
     realm.write(() => {
       let obj = realm.objects('Sidekiq').filtered('paramUuid="' + paramUuid + '"')[0];
-      realm.delete(obj);
+      if (!!obj)
+        realm.delete(obj);
     });
   }
 

--- a/app/services/visit_service.js
+++ b/app/services/visit_service.js
@@ -2,7 +2,6 @@ import DeviceInfo from 'react-native-device-info';
 import WebService from './web_service';
 import endpointHelper from '../helpers/endpoint_helper';
 import Visit from '../models/Visit';
-import User from '../models/User';
 import Sidekiq from '../models/Sidekiq';
 
 class VisitService extends WebService {
@@ -17,10 +16,8 @@ class VisitService extends WebService {
   // private method
   async _buildParams(uuid) {
     const visit = Visit.find(uuid);
-    const user = User.find(visit.user_uuid);
     return {
       visit: {
-        user_id: !!user ? user.id : null,
         user_uuid: visit.user_uuid,
         visit_date: visit.visit_date,
         pageable_id: visit.pageable_id,


### PR DESCRIPTION
This pull request makes some updates as listed below:
- Remove user_id from the Visit API request
- Prevent errors when deleting the Sidekiq realm
- Fix the error of the AD_ID permission that was reported by the Google Play Console after updating the API level to 33