### PR TITLE
Make enhancement to prevent the notification is not saving when recei…

### DIFF
--- a/app/db/migrations/v7/notification.js
+++ b/app/db/migrations/v7/notification.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const Notification = {
+  name: 'Notification',
+  primaryKey: 'uuid',
+  properties: {
+    uuid: 'string',
+    id: 'int?',
+    title: 'string',
+    content: 'string',
+    received_date: { type: 'date', optional: true },
+    is_read: { type: 'bool', default: false },
+    data: 'string?'
+  }
+};
+
+export default Notification;

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -8,6 +8,7 @@ import schemaV3 from './schemas/schemaV3';
 import schemaV4 from './schemas/schemaV4';
 import schemaV5 from './schemas/schemaV5';
 import schemaV6 from './schemas/schemaV6';
+import schemaV7 from './schemas/schemaV7';
 
 const schemas = [
   schemaV1,
@@ -16,6 +17,7 @@ const schemas = [
   schemaV4,
   schemaV5,
   schemaV6,
+  schemaV7,
 ];
 
 // the first schema to update to is the current schema version

--- a/app/db/schemas/schemaV7.js
+++ b/app/db/schemas/schemaV7.js
@@ -1,0 +1,34 @@
+import Institution from '../migrations/v3/institution'
+import User from '../migrations/v4/user';
+import Form from '../migrations/v4/form'
+import Notification from '../migrations/v7/notification';
+import Video from '../migrations/v4/video'
+import Question from '../migrations/v4/question'
+import Country from '../migrations/v5/country'
+import Option from '../migrations/v6/option'
+import helper from './helper';
+
+const changedSchemas = [
+  { label: 'User', data: User },
+  { label: 'Institution', data: Institution },
+  { label: 'Form', data: Form },
+  { label: 'Option', data: Option },
+  { label: 'Notification', data: Notification },
+  { label: 'Video', data: Video },
+  { label: 'Question', data: Question },
+  { label: 'Country', data: Country }
+];
+
+const schemaV7 = {
+  schema: helper.getSchemas(changedSchemas),
+  schemaVersion: 7,
+  migration: (oldRealm, newRealm) => {
+    const oldObjects = oldRealm.objects('Notification');
+    const newObjects = newRealm.objects('Notification');
+    for (let i = 0; i < oldObjects.length; i++) {
+      newObjects[i].id = !oldObjects[i].id ? oldObjects[i].id : null;
+    }
+  }
+}
+
+export default schemaV7;

--- a/app/models/Notification.js
+++ b/app/models/Notification.js
@@ -6,6 +6,7 @@ const Notification = (() => {
   return {
     all,
     find,
+    findById,
     create,
     update,
     hasUnread,
@@ -19,6 +20,10 @@ const Notification = (() => {
 
   function find(uuid) {
     return realm.objects(MODEL_NAME).filtered(`uuid = '${uuid}'`)[0];
+  }
+
+  function findById(id) {
+    return realm.objects(MODEL_NAME).filtered(`id = ${id}`)[0];
   }
 
   function create(item) {
@@ -59,6 +64,7 @@ const Notification = (() => {
   function _buildData(item) {
     let params = {
       uuid: uuidv4(),
+      id: item.id,
       title: item.title,
       content: item.body,
       received_date: new Date(),

--- a/app/screens/notification_list/notification_list.js
+++ b/app/screens/notification_list/notification_list.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { View, Text, FlatList, Image } from 'react-native';
 
+import Form from '../../models/Form';
 import Notification from '../../models/Notification';
 import NotificationItem from '../../components/Notification/notificationItem';
 import ConfirmModal from '../../components/confirmModal';
@@ -36,6 +37,7 @@ class NotificationList extends Component {
 
   deleteNotification = () => {
     Notification.destroy(this.state.selectedUuid);
+    Form.deleteAllWithDependency()
 
     this.setState({
       showModal: false,

--- a/app/services/visit_service.js
+++ b/app/services/visit_service.js
@@ -5,6 +5,9 @@ import Sidekiq from '../models/Sidekiq';
 
 class VisitService extends WebService {
   async upload(uuid) {
+    if (!Visit.find(uuid))
+      return;
+
     this.post(endpointHelper.listingEndpoint('visits'), JSON.stringify(await this._buildParams(uuid)), 'application/json')
       .then(res => {
         Sidekiq.destroy(uuid);
@@ -17,7 +20,7 @@ class VisitService extends WebService {
     const visit = Visit.find(uuid);
     return {
       visit: {
-        user_uuid: visit.user_uuid || null,
+        user_uuid: !!visit.user_uuid ? visit.user_uuid : null,
         visit_date: visit.visit_date,
         pageable_id: visit.pageable_id,
         pageable_type: visit.pageable_type,

--- a/index.js
+++ b/index.js
@@ -6,54 +6,10 @@ import {AppRegistry} from 'react-native';
 import App from './App';
 import {name as appName} from './app.json';
 
-import messaging from '@react-native-firebase/messaging';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import Notification from './app/models/Notification';
-import * as RootNavigation from './app/navigators/app_navigator';
-import SurveyFormService from './app/services/survey_form_service';
 import notificationService from './app/services/notification_service';
-import Visit from './app/models/Visit';
 
-messaging().onMessage(async remoteMessage => {
-  notificationService.create(remoteMessage);
-});
-
-messaging().setBackgroundMessageHandler(async remoteMessage => {
-  if (Object.keys(remoteMessage.data).length > 0) {
-    const data =  JSON.parse(remoteMessage.data.payload)
-    if (!!data.form_id)
-      new SurveyFormService().findAndSave(data.form_id);
-  }
-
-  notificationService.create(remoteMessage);
-});
-
-const navigateToNextScreen = async (screenName, params) => {
-  if (!!JSON.parse(await AsyncStorage.getItem('CURRENT_USER'))) {
-    setTimeout(() => {
-      RootNavigation.navigate(screenName, params)
-    }, 100)
-  }
-}
-
-messaging().onNotificationOpenedApp(remoteMessage => {
-  const notification = Notification.findByTitle(remoteMessage.notification.title);
-  if (Object.keys(remoteMessage.data).length > 0) {
-    const data =  JSON.parse(remoteMessage.data.payload)
-    if (!!data.form_id) {
-      Visit.upload({
-        pageable_type: 'NotificationOccurrence',
-        pageable_id: data.notification_occurrence_id,
-        code: 'open_remote_notification',
-        name: 'Open remote notification',
-      });
-
-      navigateToNextScreen('SurveyFormScreen', { uuid: notification.uuid, form_id: data.form_id, title: remoteMessage.notification.title });
-      return
-    }
-  }
-
-  navigateToNextScreen('NotificationDetailScreen', { uuid: notification.uuid });
-});
+notificationService.onNotificationArrivedInBackground();
+notificationService.onNotificationArrivedInForeground();
+notificationService.onNotificationOpenedApp();
 
 AppRegistry.registerComponent(appName, () => App);


### PR DESCRIPTION
This pull request makes some enhancements to resolve the issue where the notification is not saving to the realm after receiving the push notification.

- The cause of the issue: the event (firebase messaging event) that called when the app received the push notification while the app is in the quit state is sometimes not called, so we cannot save the received push notification.
- The solution: when the user presses on the push notification (while the app is in the quit state), we will check and save the notification (including the survey form).

** Note: there is still a case that the notification will not be saved with the following steps:
1. The app receives a push notification while it is in the quit state and the Firebase messaging event is not called
2. The user doesn't press on the push notification to open the app, they open the app normally by pressing on the app icon
3. The notification will not be saved to the realm since we cannot get the data from the push notification