### PR TITLE
Show message and a button to download survey form when there is no in…

### DIFF
--- a/app/components/SurveyForms/SurveyFormRedownloadButtonComponent.js
+++ b/app/components/SurveyForms/SurveyFormRedownloadButtonComponent.js
@@ -1,0 +1,62 @@
+import React, {useState} from 'react';
+import {ActivityIndicator, View, Text, TouchableOpacity} from 'react-native';
+import Icon from 'react-native-vector-icons/Feather';
+import NetInfo from "@react-native-community/netinfo";
+
+import { Color, FontFamily, FontSize } from '../../assets/stylesheets/base_style';
+import SurveyFormService from '../../services/survey_form_service';
+
+const noInternetMessage = 'មិនមានកម្រងសំណួរនៃការស្ទង់មតិដែលអាចបណ្ដាលមកពីមិនមានប្រព័ន្ធអ៊ីនធឺណិត។ សូមចុចប៊ូតុងខាងក្រោមដើម្បីទាញយកកម្រងសំណួរនៃការស្ទង់មតិ។';
+
+const SurveyFormRedownloadButtonComponent = (props) => {
+  const [message, setMessage] = useState(noInternetMessage);
+  const [icon, setIcon] = useState('wifi-off');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const downloadSurveyForm = () => {
+    NetInfo.fetch().then(state => {
+      if (state.isConnected) {
+        setIsLoading(true);
+        new SurveyFormService().findAndSave(props.formId, () => {
+          props.setForm()
+          setIsLoading(false);
+        }, (error) => {
+          setMessage('មានបញ្ហារអាក់រអួលក្នុងការទាញយកការស្ទង់មតិ។ សូមពិនិត្យមើលប្រព័ន្ធអ៊ីនធឺណិតរបស់អ្នកហើយព្យាយាមម្តងទៀត។');
+          setIcon('info');
+          setIsLoading(false);
+        });
+      }
+      else
+        setMessage(noInternetMessage);
+    });
+  }
+
+  const renderMessage = () => {
+    return (
+      <React.Fragment>
+        <Icon name={icon} size={85} color={Color.lightGray} style={{marginTop: -30}} />
+        <Text style={{fontFamily: FontFamily.body, marginBottom: 26, marginTop: 16}}>
+          {message}
+        </Text>
+
+        <TouchableOpacity onPress={() => downloadSurveyForm()} mode="contained"
+          style={{borderRadius: 6, height: 48, justifyContent: 'center', alignItems: 'center', flexDirection: 'row', backgroundColor: Color.primary, paddingHorizontal: 16}}
+        >
+          <Icon name='download' size={20} color={Color.white} />
+          <Text style={{fontFamily: FontFamily.body, fontSize: FontSize.body, color: Color.white, lineHeight: 28, marginLeft: 8}}>ទាញយកការស្ទង់មតិ</Text>
+        </TouchableOpacity>
+      </React.Fragment>
+    )
+  }
+
+  return (
+    <View style={{flex: 1, justifyContent:'center', alignItems: 'center', paddingHorizontal: 16}}>
+      {
+        isLoading ? <View style={{flex: 1, justifyContent: 'center'}}><ActivityIndicator size="large" color={Color.primary} /></View>
+        : renderMessage()
+      }
+    </View>
+  )
+}
+
+export default SurveyFormRedownloadButtonComponent;

--- a/app/components/SurveyForms/SurveyFormRedownloadButtonComponent.js
+++ b/app/components/SurveyForms/SurveyFormRedownloadButtonComponent.js
@@ -6,7 +6,7 @@ import NetInfo from "@react-native-community/netinfo";
 import { Color, FontFamily, FontSize } from '../../assets/stylesheets/base_style';
 import SurveyFormService from '../../services/survey_form_service';
 
-const noInternetMessage = 'មិនមានកម្រងសំណួរនៃការស្ទង់មតិដែលអាចបណ្ដាលមកពីមិនមានប្រព័ន្ធអ៊ីនធឺណិត។ សូមចុចប៊ូតុងខាងក្រោមដើម្បីទាញយកកម្រងសំណួរនៃការស្ទង់មតិ។';
+const noInternetMessage = 'មិនមានកម្រងសំណួរនៃការស្ទង់មតិ! បញ្ហាអាចបណ្ដាលមកពីមិនមានប្រព័ន្ធអ៊ីនធឺណិត។ សូមចុចប៊ូតុងខាងក្រោមដើម្បីទាញយកកម្រងសំណួរនៃការស្ទង់មតិ។';
 
 const SurveyFormRedownloadButtonComponent = (props) => {
   const [message, setMessage] = useState(noInternetMessage);
@@ -21,7 +21,7 @@ const SurveyFormRedownloadButtonComponent = (props) => {
           props.setForm()
           setIsLoading(false);
         }, (error) => {
-          setMessage('មានបញ្ហារអាក់រអួលក្នុងការទាញយកការស្ទង់មតិ។ សូមពិនិត្យមើលប្រព័ន្ធអ៊ីនធឺណិតរបស់អ្នកហើយព្យាយាមម្តងទៀត។');
+          setMessage('មានបញ្ហារអាក់រអួលក្នុងការទាញយកកម្រងសំណួរនៃការស្ទង់មតិ។ សូមពិនិត្យមើលប្រព័ន្ធអ៊ីនធឺណិតរបស់អ្នកហើយព្យាយាមម្តងទៀត។');
           setIcon('info');
           setIsLoading(false);
         });
@@ -43,7 +43,7 @@ const SurveyFormRedownloadButtonComponent = (props) => {
           style={{borderRadius: 6, height: 48, justifyContent: 'center', alignItems: 'center', flexDirection: 'row', backgroundColor: Color.primary, paddingHorizontal: 16}}
         >
           <Icon name='download' size={20} color={Color.white} />
-          <Text style={{fontFamily: FontFamily.body, fontSize: FontSize.body, color: Color.white, lineHeight: 28, marginLeft: 8}}>ទាញយកការស្ទង់មតិ</Text>
+          <Text style={{fontFamily: FontFamily.body, fontSize: FontSize.body, color: Color.white, lineHeight: 28, marginLeft: 8}}>ទាញយកកម្រងសំណួរ</Text>
         </TouchableOpacity>
       </React.Fragment>
     )

--- a/app/services/survey_form_service.js
+++ b/app/services/survey_form_service.js
@@ -22,14 +22,14 @@ class SurveyFormService extends WebService {
     super();
   }
 
-  findAndSave(id, callback) {
+  findAndSave(id, successCallback, failureCallback) {
     this.get(endpointHelper.detailEndpoint('survey_forms', id))
       .then(response => JSON.parse(response.data))
       .then(data => {
         this._saveForm(data);
-        this._saveSectionsAndQuestions(data.sections, id, callback);
+        this._saveSectionsAndQuestions(data.sections, id, successCallback);
       })
-      .catch(error => console.log('survey form error = ', error))
+      .catch(error => !!failureCallback && failureCallback(error))
   }
 
   submitSurvey(answers, quizUuid) {
@@ -79,6 +79,19 @@ class SurveyFormService extends WebService {
       return true
 
     return false
+  }
+
+  isExist(formId) {
+    const sections = Section.findByFormId(formId)
+    if (!Form.findById(formId) || sections.length == 0)
+      return false;
+
+    Section.findByFormId(formId).map(section => {
+      if (!Question.findBySectionId(section.id))
+        return false
+    });
+
+    return true;
   }
 
   // private method


### PR DESCRIPTION
This pull request updates the survey form screen as follows:
- Check the survey form, survey sections, and survey questions if one of them does not exist then we will mark the survey form as not exist
- Show a message and a button to download the survey form on the survey screen when the survey form does not exist

Below are the screenshots of the message:
1. Message 1: The survey form does not exist and the user device doesn't have an internet connection
2. Message 2: This message will be shown when there is an error while sending a request to get the survey form (when the user presses the "ទាយយកការស្ទង់មតិ" button)

[survey download button.zip](https://github.com/kawsangs/migrant-worker-mobile/files/13213595/survey.download.button.zip)
