### PR TITLE
Update the logic to show the survey question and delete specific surv…

### DIFF
--- a/app/components/AlertMessage.js
+++ b/app/components/AlertMessage.js
@@ -55,7 +55,9 @@ class AlertMessage extends Component {
   render() {
     return (
       <Portal>
-        <Dialog visible={this.props.show} style={{borderRadius: 2, backgroundColor: Color.white}}>
+        <Dialog visible={this.props.show} style={{borderRadius: 2, backgroundColor: Color.white}} dismissable={true}
+          onDismiss={() => !!this.props.onDismiss && this.props.onDismiss()}
+        >
           <Dialog.Content style={{marginTop: 16}}>
             {this.renderTitle()}
             <Text style={{marginTop: 16}}>{ this.props.message }</Text>

--- a/app/components/Notification/notificationItem.js
+++ b/app/components/Notification/notificationItem.js
@@ -24,7 +24,7 @@ class NotificationItem extends React.Component {
   }
 
   deleteNotification = () => {
-    this.props.showDeleteModal(this.props.notification.uuid);
+    this.props.showDeleteModal(this.props.notification);
     this.itemRef.close();
   }
 

--- a/app/components/SurveyForms/SurveyFormAlertMessageComponent.js
+++ b/app/components/SurveyForms/SurveyFormAlertMessageComponent.js
@@ -33,6 +33,7 @@ const SurveyFormAlertMessageComponent = React.forwardRef((props, ref) => {
             message={"តើអ្នក​ពិតជា​ចង់​ចាកចេញ​ពី​ការស្ទង់​មតិ​នេះ​មែន​ទេ?"}
             onPressAction={() => exitSurvey()}
             onPressCancel={() => setVisible(false)}
+            onDismiss={() => setVisible(false)}
             audio='exit_survey_20230929.mp3'
           />
 })

--- a/app/components/SurveyForms/SurveyFormButtonComponent.js
+++ b/app/components/SurveyForms/SurveyFormButtonComponent.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {View} from 'react-native';
 
 import BigButtonComponent from '../shared/BigButtonComponent';
@@ -14,6 +14,11 @@ const BUTTONS = {
 
 const SurveyFormButtonComponent = React.forwardRef((props, ref) => {
   const [isValid, setIsValid] = useState(false);
+
+  useEffect(() => {
+    if (props.visibleQuestions.filter(q => q == true).length == 0 && props.currentSection == props.sections.length - 1)
+      setIsValid(true);
+  }, [props.currentSection]);
 
   useImperativeHandle(ref, () => ({
     validateForm,

--- a/app/components/SurveyForms/SurveyFormContentComponent.js
+++ b/app/components/SurveyForms/SurveyFormContentComponent.js
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import SurveyFormQuestionComponent from './SurveyFormQuestionComponent';
 import SurveyFormButtonComponent from './SurveyFormButtonComponent';
+import SurveyFormEndMessageComponent from './SurveyFormEndMessageComponent';
 import Section from '../../models/Section';
 import Question from '../../models/Question';
 import SurveyFormService from '../../services/survey_form_service';
@@ -109,6 +110,7 @@ const SurveyFormContentComponent = (props) => {
               answers={answers}
               sections={sections}
               currentSection={currentSection}
+              visibleQuestions={visibleQuestions}
               onPress={() => goNextOrFinish()}
            />
   }
@@ -116,6 +118,9 @@ const SurveyFormContentComponent = (props) => {
   return (
     <React.Fragment>
       <ScrollView contentContainerStyle={{flexGrow: 1, paddingHorizontal: 16, paddingBottom: 26}}>
+        {currentSection == sections.length - 1 &&
+          <SurveyFormEndMessageComponent visibleQuestions={visibleQuestions}/>
+        }
         { renderQuestionsOfSection() }
       </ScrollView>
       { renderButton() }

--- a/app/components/SurveyForms/SurveyFormEndMessageComponent.js
+++ b/app/components/SurveyForms/SurveyFormEndMessageComponent.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {View, Text} from 'react-native';
+import Icon from 'react-native-vector-icons/Feather';
+
+import { Color, FontFamily } from '../../assets/stylesheets/base_style';
+
+const SurveyFormEndMessageComponent = (props) => {
+  return (
+    <View style={[{paddingTop: 12, justifyContent: 'center'}, props.visibleQuestions.filter(q => q == true).length == 0 && {flex: 1}]}>
+      <Text style={{fontFamily: FontFamily.title}}>អរគុណសម្រាប់ការចូលរួមការស្ទង់មតិ</Text>
+
+      <View style={{flexDirection: 'row', paddingHorizontal: 12, paddingVertical: 16, borderWidth: 1.5, borderColor: '#dbdbdb', borderRadius: 10, marginTop: 10, backgroundColor: Color.white}}>
+        <Icon name='info' size={24} color={Color.primary} />
+        <View style={{fontFamily: FontFamily.body, marginLeft: 12}}>
+          <Text>ដើម្បីចាក់ចេញពីការស្ទង់មតិ សូមចុចលើប៊ូតុង <Text style={{fontFamily: FontFamily.title}}>"បញ្ចប់"</Text>។</Text>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+export default SurveyFormEndMessageComponent;

--- a/app/models/Criteria.js
+++ b/app/models/Criteria.js
@@ -4,6 +4,7 @@ const Criteria = (() => {
   return {
     getAll,
     deleteAll,
+    deleteAllByQuestionId,
     upsertCollection,
     upsert,
     byQuestion,
@@ -23,6 +24,15 @@ const Criteria = (() => {
     if (collection.length > 0) {
       realm.write(() => {
         realm.delete(collection);
+      });
+    }
+  }
+
+  function deleteAllByQuestionId(questionId) {
+    const criterias = byQuestion(questionId);
+    if (criterias.length > 0) {
+      realm.write(() => {
+        realm.delete(criterias);
       });
     }
   }

--- a/app/models/Form.js
+++ b/app/models/Form.js
@@ -15,6 +15,7 @@ const Form = (() => {
     isDownloaded,
     deleteAllWithDependency,
     deleteAll,
+    deleteByIdWithDependency,
     getPendingDownload,
     upsertCollection,
     upsert,
@@ -63,6 +64,20 @@ const Form = (() => {
     if (collection.length > 0) {
       realm.write(() => {
         realm.delete(collection);
+      });
+    }
+  }
+
+  function deleteByIdWithDependency(id) {
+    const form = findById(id);
+    if (!!form) {
+      Question.byForm(id).map(question => {
+        Option.deleteAllByQuestionId(question.id);
+        Criteria.deleteAllByQuestionId(question.id);
+      });
+      Question.deleteAllByFormId(id);
+      realm.write(() => {
+        realm.delete(form);
       });
     }
   }

--- a/app/models/Option.js
+++ b/app/models/Option.js
@@ -4,6 +4,7 @@ const Option = (() => {
   return {
     getAll,
     deleteAll,
+    deleteAllByQuestionId,
     isDownloaded,
     getPendingDownload,
     upsertCollection,
@@ -25,6 +26,15 @@ const Option = (() => {
     if (collection.length > 0) {
       realm.write(() => {
         realm.delete(collection);
+      });
+    }
+  }
+
+  function deleteAllByQuestionId(questionId) {
+    const options = byQuestion(questionId);
+    if (options.length > 0) {
+      realm.write(() => {
+        realm.delete(options);
       });
     }
   }

--- a/app/models/Question.js
+++ b/app/models/Question.js
@@ -10,6 +10,7 @@ const Question = (() => {
   return {
     getAll,
     deleteAll,
+    deleteAllByFormId,
     isDownloaded,
     getPendingDownload,
     upsertCollection,
@@ -39,6 +40,15 @@ const Question = (() => {
     if (collection.length > 0) {
       realm.write(() => {
         realm.delete(collection);
+      });
+    }
+  }
+
+  function deleteAllByFormId(formId) {
+    const questions = byForm(formId);
+    if (questions.length > 0) {
+      realm.write(() => {
+        realm.delete(questions);
       });
     }
   }

--- a/app/screens/notification_list/notification_list.js
+++ b/app/screens/notification_list/notification_list.js
@@ -19,6 +19,7 @@ class NotificationList extends Component {
       selectedUuid: null,
       showModal: false,
     };
+    this.selectedNotification = null;
   }
 
   componentDidMount() {
@@ -36,9 +37,11 @@ class NotificationList extends Component {
   }
 
   deleteNotification = () => {
-    Notification.destroy(this.state.selectedUuid);
-    Form.deleteAllWithDependency()
+    const data = !!this.selectedNotification ? JSON.parse(this.selectedNotification.data) : null;
+    if (!!data && !!data.form_id)
+      Form.deleteByIdWithDependency(data.form_id);
 
+    Notification.destroy(this.state.selectedUuid);
     this.setState({
       showModal: false,
       notifications: Notification.all(),
@@ -46,11 +49,12 @@ class NotificationList extends Component {
     })
   }
 
-  showDeleteModal = (uuid) => {
+  showDeleteModal = (notification) => {
     this.setState({
       showModal: true,
-      selectedUuid: uuid
+      selectedUuid: notification.uuid
     })
+    this.selectedNotification = notification;
   }
 
   renderEmptyMessage = () => {

--- a/app/services/survey_form_service.js
+++ b/app/services/survey_form_service.js
@@ -45,6 +45,9 @@ class SurveyFormService extends WebService {
 
     let queries = [];
     criterias.map((criteria, index) => {
+      if (!criteria.response_value && !criteria.question_code)
+        queries.push('true')
+
       let matchedAnswer = null;
       for (let section in answers) {
         if (Object.keys(answers[section]).length == 0 || section > currentSection)


### PR DESCRIPTION
This pull request makes some updates to the survey form screen as follows:
- Update the logic to show/hide the survey question
- Show a message at the end of the survey form
- Add press outside of the confirm exit survey dialog to close the dialog
- Delete only the survey form and its dependencies (questions, options, and criteria) when the user deletes the notification (the previous code, deletes all the survey and its dependencies when the user deletes a notification)

Below are the screenshots of the ending screen of the survey with the newly added message:
[Survey end message.zip](https://github.com/kawsangs/migrant-worker-mobile/files/13263329/Survey.end.message.zip)
